### PR TITLE
show known server names on error embeds

### DIFF
--- a/src/handler/info-channel.handler.ts
+++ b/src/handler/info-channel.handler.ts
@@ -11,6 +11,7 @@ import {
 import { Discord, Once } from "discordx";
 import { container } from "tsyringe";
 import { Team } from "../enums/team.enum.js";
+import { ServerInfo } from "../model/server-info.model.js";
 import { ComponentService } from "../services/component.service.js";
 import { Logger } from "../services/logger.service.js";
 import { ServerQueryError, ServerService } from "../services/server.service.js";
@@ -156,7 +157,7 @@ export class InfoChannelHandler {
     for (const [index, server] of servers.entries()) {
       const position = index + 1;
 
-      let serverInfo;
+      let serverInfo: ServerInfo;
       try {
         serverInfo = await this.serverService.getServerInfo(server);
         serverEmbeds.push(this.componentService.buildServerInfoEmbed(serverInfo, position));

--- a/src/model/squad-server.model.ts
+++ b/src/model/squad-server.model.ts
@@ -6,6 +6,7 @@ const IP_REGEX = /^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}$/;
 export class SquadServer {
   public readonly ip: string;
   public readonly queryPort: number;
+  public name?: string;
 
   public readonly rconEnabled: boolean = false;
   public readonly rconPort?: number;
@@ -71,6 +72,10 @@ export class SquadServer {
 
   public toRconPortString(): string {
     return `${this.ip}:${this.rconPort}`;
+  }
+
+  public equals(other: SquadServer): boolean {
+    return this.ip === other.ip && this.queryPort === other.queryPort;
   }
 
   private validateIp(ip: string): string {

--- a/src/services/component.service.ts
+++ b/src/services/component.service.ts
@@ -87,14 +87,24 @@ export class ComponentService {
     position: number,
     message?: string
   ): EmbedBuilder {
-    return new EmbedBuilder()
-      .setTitle(`${squadServer.ip}:${squadServer.queryPort}`)
-      .setDescription(
-        message ? message : "Unexpected error occured. Could not retrieve server information."
-      )
-      .setFooter({
-        text: this.buildFooter(position),
-      });
+    const embed = new EmbedBuilder();
+    const errorMessage = message
+      ? message
+      : "Unexpected error occured. Could not retrieve server information.";
+
+    if (squadServer.name) {
+      embed
+        .setTitle(squadServer.name)
+        .setDescription(`${squadServer.ip}:${squadServer.queryPort}\n${errorMessage}`);
+    } else {
+      embed.setTitle(`${squadServer.ip}:${squadServer.queryPort}`).setDescription(errorMessage);
+    }
+
+    embed.setFooter({
+      text: this.buildFooter(position),
+    });
+
+    return embed;
   }
 
   public buildPlayerInfoEmbed(serverInfo: ServerInfo, team: Team, position: number): EmbedBuilder {

--- a/src/services/server.service.ts
+++ b/src/services/server.service.ts
@@ -35,9 +35,10 @@ export class ServerService {
   }
 
   public async getServerInfo(server: SquadServer): Promise<ServerInfo> {
-    let serverInfo;
+    let serverInfo: ServerInfo;
     try {
       serverInfo = await this.serverQueryService.getServerInfo(server);
+      this.setServerName(server, serverInfo.serverName);
     } catch (error: any) {
       throw new ServerQueryError("Server Query Endpoint is not responding");
     }
@@ -58,5 +59,13 @@ export class ServerService {
     }
 
     return serverInfo;
+  }
+
+  private setServerName(server: SquadServer, name: string) {
+    for (const squadServer of this.squadServers) {
+      if (squadServer.equals(server)) {
+        squadServer.name = name;
+      }
+    }
   }
 }

--- a/src/services/server.service.ts
+++ b/src/services/server.service.ts
@@ -18,6 +18,12 @@ export class ServerService {
 
     for (const server of servers) {
       const squadServer = new SquadServer(server);
+      if (this.contains(squadServer)) {
+        throw new Error(
+          `The config contains the server '${squadServer.toQueryPortString()}' twice. A server can only be added once.`
+        );
+      }
+
       this.squadServers.push(squadServer);
 
       if (squadServer.rconEnabled) {
@@ -61,7 +67,17 @@ export class ServerService {
     return serverInfo;
   }
 
-  private setServerName(server: SquadServer, name: string) {
+  private contains(server: SquadServer): boolean {
+    for (const squadServer of this.squadServers) {
+      if (squadServer.equals(server)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private setServerName(server: SquadServer, name: string): void {
     for (const squadServer of this.squadServers) {
       if (squadServer.equals(server)) {
         squadServer.name = name;


### PR DESCRIPTION
- if the server query endpoint is not responding the server name will now be shown in the title of the error embed if the server name for that IP is known. Otherwise only the IP will be shown as previously