### PR TITLE
Bug Fixes - rcon and faction parsing

### DIFF
--- a/src/rcon/rcon.ts
+++ b/src/rcon/rcon.ts
@@ -200,7 +200,7 @@ export class Rcon {
     }
 
     let offset = 0;
-    while (offset < this.responseData.length) {
+    while (offset <= this.responseData.length - 4) {
       const packet = this.readPacket(this.responseData, offset);
       if (packet) {
         offset += packet.size + 4;

--- a/src/services/server-info.service.ts
+++ b/src/services/server-info.service.ts
@@ -30,6 +30,7 @@ export enum ServerStatus {
 }
 
 const FACTION_REGEX_PATTERN = /^.+_([A-Z]{3,})$/;
+const PREFIX_FACTION_REGEX_PATTERN = /^([A-Z]{3,})_.+$/;
 
 @singleton()
 export class ServerInfoService {
@@ -98,12 +99,17 @@ export class ServerInfoService {
     if (!teamString) return undefined;
 
     const match = teamString.match(FACTION_REGEX_PATTERN);
-    if (!match || match.length != 2) {
-      this.logger.warn("Could not parse faction from team: [%s]", teamString);
-      return "Unknown";
+    if (match && match.length == 2) {
+      return match[1];
     }
 
-    return match[1];
+    const prefixMatch = teamString.match(PREFIX_FACTION_REGEX_PATTERN);
+    if (prefixMatch && prefixMatch.length == 2) {
+      return prefixMatch[1];
+    }
+
+    this.logger.warn("Could not parse faction from team: [%s]", teamString);
+    return "Unknown";
   }
 
   private async getRconConnection(server: SquadServer): Promise<Rcon> {


### PR DESCRIPTION
- Fixes offset out of bounds error when decoding partial RCON data (Probably fixes #28)
- Fixes team string parsing when the team is listed at the beginning instead of at the end